### PR TITLE
ISSUE - Cannot add LinkKit with Carthage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ISSUE - Carthage is broken for LinkKit
+# ISSUE - Cannot add LinkKit with Carthage
 
 ### Please fix
 

--- a/README.md
+++ b/README.md
@@ -1,142 +1,19 @@
-# Plaid Link for iOS
+# ISSUE - Carthage is broken for LinkKit
 
-📚 Detailed instructions on how to integrate with Plaid Link for iOS can be found in our main documentation at [plaid.com/docs/link/ios][link-ios-docs].
+### Please fix
 
-📱 This repository contains sample applications in [Objective-C](LinkDemo-ObjC) and [Swift](LinkDemo-Swift) (requires Xcode 10.2) that demonstrate integration and use of Plaid Link for iOS.
+The error from `carthage update`:
+```
+*** Downloading binary-only framework LinkKit at "https://raw.githubusercontent.com/plaid/plaid-link-ios/master/LinkKit.json"
+A shell task (/usr/bin/env unzip -uo -qq -d /var/folders/cq/fyk6h3vn1sx_01fm1y40pz3w0000gn/T/carthage-archive.L4JKVn /Users/jesse/Library/Caches/org.carthage.CarthageKit/binaries/LinkKit/1.1.27/LinkKit.framework.zip) failed with exit code 9:
+[/Users/jesse/Library/Caches/org.carthage.CarthageKit/binaries/LinkKit/1.1.27/LinkKit.framework.zip]
+  End-of-central-directory signature not found.  Either this file is not
+  a zipfile, or it constitutes one disk of a multi-part archive.  In the
+  latter case the central directory and zipfile comment will be found on
+  the last disk(s) of this archive.
+unzip:  cannot find zipfile directory in one of /Users/jesse/Library/Caches/org.carthage.CarthageKit/binaries/LinkKit/1.1.27/LinkKit.framework.zip or
+        /Users/jesse/Library/Caches/org.carthage.CarthageKit/binaries/LinkKit/1.1.27/LinkKit.framework.zip.zip, and cannot find /Users/jesse/Library/Caches/org.carthage.CarthageKit/binaries/LinkKit/1.1.27/LinkKit.framework.zip.ZIP, period.
+```
 
-## About the LinkDemo Xcode projects
+# Also please enable issues in this repository!
 
-ℹ️  In order to compile the source code that uses the [custom configuration](https://plaid.com/docs/link/ios#configure_custom) add `-DUSE_CUSTOM_CONFIG` to `OTHER_SWIFT_FLAGS` in the LinkDemo-Swift build settings and to `OTHER_CFLAGS` in the LinkDemo-ObjC build settings.
-
-![Use Custom Config](/docs/images/use_custom_config.jpg)
-
-🤖 Throughout the source code there are HTML-like comments such as <code>&lt;!-- SMARTDOWN_PRESENT_CUSTOM --&gt;</code>, they are used to update the code examples in the [documentation][link-ios-docs] from the sample applicationsʼ code ensuring that the examples are up-to-date and working as intended.
-
-[link-ios-docs]: https://plaid.com/docs/link/ios
-
-## Acknowledgements
-
-<!-- ACKNOWLEDGMENTS -->
-
-### i18next
-
-The MIT License (MIT)
-
-Copyright (c) 2013-2015 PrePlay, Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-### OCHamcrest
-
-OCHamcrest by Jon Reid, https://qualitycoding.org/
-Copyright 2017 hamcrest.org
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-Neither the name of Hamcrest nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-(BSD License)
-
-### OCMockito
-
-OCMockito by Jon Reid, https://qualitycoding.org/
-Copyright 2017 Jonathan M. Reid
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-(MIT License)
-
------
-
-TPDWeakProxy:
-
-The MIT License (MIT)
-
-Copyright © 2013 Tetherpad
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-### onepassword-app-extension
-
-Copyright (c) 2014 AgileBits Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-### SimulatorStatusMagiciOS
-
-The MIT License (MIT)
-
-Copyright (c) 2014 Shiny Development
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.


### PR DESCRIPTION
The error from `carthage update`:
```
*** Downloading binary-only framework LinkKit at "https://raw.githubusercontent.com/plaid/plaid-link-ios/master/LinkKit.json"
A shell task (/usr/bin/env unzip -uo -qq -d /var/folders/cq/fyk6h3vn1sx_01fm1y40pz3w0000gn/T/carthage-archive.L4JKVn /Users/jesse/Library/Caches/org.carthage.CarthageKit/binaries/LinkKit/1.1.27/LinkKit.framework.zip) failed with exit code 9:
[/Users/jesse/Library/Caches/org.carthage.CarthageKit/binaries/LinkKit/1.1.27/LinkKit.framework.zip]
  End-of-central-directory signature not found.  Either this file is not
  a zipfile, or it constitutes one disk of a multi-part archive.  In the
  latter case the central directory and zipfile comment will be found on
  the last disk(s) of this archive.
unzip:  cannot find zipfile directory in one of /Users/jesse/Library/Caches/org.carthage.CarthageKit/binaries/LinkKit/1.1.27/LinkKit.framework.zip or
        /Users/jesse/Library/Caches/org.carthage.CarthageKit/binaries/LinkKit/1.1.27/LinkKit.framework.zip.zip, and cannot find /Users/jesse/Library/Caches/org.carthage.CarthageKit/binaries/LinkKit/1.1.27/LinkKit.framework.zip.ZIP, period.
```

# Also please enable issues in this repository!