### PR TITLE
Failed to build module

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ Select your desired use-case in [`ViewController.didTapButton`](/search?q=didTap
 [link-sdk-url]: https://cocoapods.org/pods/Plaid
 [link-1-2-migration]: https://plaid.com/docs/link/ios/ios-v2-migration
 [link-main-v1]: https://github.com/plaid/plaid-link-ios/tree/main-v1
+


### PR DESCRIPTION
Getting the following error when attempting to archive a release build:

> failed to build module 'LinkKit' from its module interface; the compiler that produced it, 'Apple Swift version 5.3 (swiftlang-1200.0.29.2 clang-1200.0.30.1)', may have used features that aren't supported by this compiler, 'Apple Swift version 5.3.1 (swiftlang-1200.0.41 clang-1200.0.32.8)'

Is it possible the compiled framework is non-compatible with Swift version 5.3.1? Using version Plaid version `2.0.9`.