### PR TITLE
Remove checks against oauthRedirectUri for swift demo

### DIFF
--- a/LinkDemo-Swift/LinkDemo-Swift/AppDelegate+OAuthSupport.swift
+++ b/LinkDemo-Swift/LinkDemo-Swift/AppDelegate+OAuthSupport.swift
@@ -20,8 +20,10 @@ extension AppDelegate {
             return false
         }
 
-        // Check that the userActivity.webpageURL is the oauthRedirectUri
-        // configured in the Plaid dashboard.
+        // The Plaid Link SDK will ignore unexpected URLs passed to `continue(from:)` as
+        // per Apple’s recommendations,  so there is no need to filter out unrelated URLs.
+        // Doing so may prevent a valid URL from being passed to `continue(from:)` and
+        // OAuth may not continue as expected.
         guard let linkOAuthHandler = window?.rootViewController as? LinkOAuthHandling,
             let handler = linkOAuthHandler.linkHandler
         else {

--- a/LinkDemo-Swift/LinkDemo-Swift/ViewController.swift
+++ b/LinkDemo-Swift/LinkDemo-Swift/ViewController.swift
@@ -13,7 +13,6 @@ import LinkKit
 
 protocol LinkOAuthHandling {
     var linkHandler: Handler? { get }
-    var oauthRedirectUri: URL? { get }
 }
 
 class ViewController: UIViewController, LinkOAuthHandling {
@@ -27,12 +26,10 @@ class ViewController: UIViewController, LinkOAuthHandling {
     // This is a simplified example for demonstaration purposes only.
     let oauthNonce: String = { return UUID().uuidString }()
 
-    #warning("Replace <#YOUR_OAUTH_REDIRECT_URI#> below with your oauthRedirectUri, which should be a universal link and must be configured in the Plaid developer dashboard")
+    #warning("Ensure your oauthRedirectUri is a universal link and is configured in the Plaid developer dashboard")
     #warning("Ensure to also replace YOUR_OAUTH_REDIRECT_URI in the Associated Domains Capability or in the LinkDemo-Swift.entitlements")
     #warning("Remember to change the application Bundle Identifier to match one you have configured for universal links")
     #warning("For more information on configuring your oauthRedirectUri, see https://plaid.com/docs/link/oauth")
-
-    var oauthRedirectUri: URL? = { URL(string: "<#YOUR_OAUTH_REDIRECT_URI#>") }()
 
     override func viewDidLoad() {
         super.viewDidLoad()


### PR DESCRIPTION
This PR removes comments & cleans up an interface in the Swift example project to be in line with [our universal link docs](https://plaid.com/docs/link/ios/#set-up-universal-links). 