### PR TITLE
Xcode 14 Update: UIViewRepresentable must be a value type

### DIFF
--- a/LinkDemo-Swift/SwiftUISupport/LinkKitSwiftUISupport.swift
+++ b/LinkDemo-Swift/SwiftUISupport/LinkKitSwiftUISupport.swift
@@ -8,7 +8,7 @@ import LinkKit
 import SwiftUI
 
 // The Controller that bridges from SwiftUI to UIKit
-final class LinkController {
+struct LinkController {
     // A wrapper enum for either a public key or link token based configuration
     enum LinkConfigurationType {
         case publicKey(LinkPublicKeyConfiguration)
@@ -22,7 +22,7 @@ final class LinkController {
     let onCreateError: ((Plaid.CreateError) -> Void)?
 
     // A reference to the `Handler`, if one has been created.
-    private(set) var linkHandler: Handler?
+    @State private(set) var linkHandler: Handler?
 
     init(
         configuration: LinkConfigurationType,


### PR DESCRIPTION
Bug Description: There is currently a runtime error in the `LinkDemo-Swift-SwiftUI` app target

Context: As of Xcode 14, any object that inherits UIViewRepresentable must be a value type. This does not generate a compiler error but when the app is run, it generates a runtime error. To resolve this runtime error I changed the class to a struct and added the `@State` binding to the handler property. The binding was necessary because otherwise the struct was mutating itself on [L90](https://github.com/plaid/plaid-link-ios/blob/master/LinkDemo-Swift/SwiftUISupport/LinkKitSwiftUISupport.swift#L90). I chose to add the state binding rather than refactor this because it was minimally invasive, an acceptable SwiftUI pattern which is the purpose of this class, and the proper SwiftUI pattern for this use case, but I am open to making a different change.

Steps to reproduce: 
1. Download the Latest [Xcode](https://developer.apple.com/xcode/) 
2. `git clone https://github.com/plaid/plaid-link-ios.git`
3. `open plaid-link-ios/LinkDemo.xcworkspace`
4.  Select `LinkDemo-Swift-SwiftUI` as the target
5. Build and Run
6. Tap `Open Plaid Link`
7. Observe runtime error 

| Before | After | 
| - | - | 
| ![Plaid Before](https://user-images.githubusercontent.com/7211499/205988250-04caa2b1-d3e9-48a5-8438-22a032ec95f4.gif)| ![Plaid After](https://user-images.githubusercontent.com/7211499/205989401-a5c597ea-eabc-4880-8e2c-7f35c2e8a6e1.gif) | 