### PR TITLE
Fix links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Plaid Link for iOS [![version][link-sdk-version]][link-sdk-pod-url] [![swift compatibility][link-sdk-swift-compat]][link-sdk-spi-url]
 
 📱 This repository contains multiple sample applications (requiring Xcode 11) that demonstrate integration and use of Plaid Link for iOS.
-* [Swift+UIKit](LinkDemo-Swift/LinkDemo-Swift-UIKit)
-* [Swift+SwiftUI](LinkDemo-Swift/LinkDemo-Swift-SwiftUI)
+* [Swift+UIKit](LinkDemo-Swift)
+* [Swift+SwiftUI](LinkDemo-SwiftUI)
 * [Objective-C](LinkDemo-ObjC)
 
 📚 Detailed instructions on how to integrate with Plaid Link for iOS can be found in our main documentation at [plaid.com/docs/link/ios][link-ios-docs]. 


### PR DESCRIPTION
The repository links are broken for Swift & SwiftUI. This fixes PR it.