### PR TITLE
Avoid logging Plaid Link tokens in demos

### DIFF
--- a/LinkDemo-ObjC/LinkDemo-ObjC/ViewController.m
+++ b/LinkDemo-ObjC/LinkDemo-ObjC/ViewController.m
@@ -64,7 +64,7 @@
         // Closure is called when a user successfully links an Item. It should take a single LinkSuccess argument,
         // containing the publicToken String and a metadata of type SuccessMetadata.
         // Ref - https://plaid.com/docs/link/ios/#onsuccess
-        NSLog(@"public-token: %@ metadata: %@", success.publicToken, success.metadata);
+        NSLog(@"Plaid Link succeeded. Exchange the public token on your backend; do not log it.");
     }];
 
     // Optional closure is called when a user exits Link without successfully linking an Item,
@@ -73,9 +73,9 @@
     // Ref - https://plaid.com/docs/link/ios/#onexit
     linkConfiguration.onExit = ^(PLKLinkExit * exit) {
         if (exit.error) {
-            NSLog(@"exit with %@\n%@", exit.error, exit.metadata);
+            NSLog(@"Plaid Link exited with error: %@", exit.error);
         } else {
-            NSLog(@"exit with %@", exit.metadata);
+            NSLog(@"Plaid Link exited without an error.");
         }
     };
 
@@ -84,7 +84,7 @@
     // what is going on as the user goes through the Plaid Link flow.
     // Ref - https://plaid.com/docs/link/ios/#onevent
     linkConfiguration.onEvent = ^(PLKLinkEvent * event) {
-        NSLog(@"Link event %@", event.eventMetadata.metadataJSON);
+        NSLog(@"Link event %@", event.eventName);
     };
 
     NSError *createError = nil;

--- a/LinkDemo-Swift/LinkDemo-Swift/ViewController.swift
+++ b/LinkDemo-Swift/LinkDemo-Swift/ViewController.swift
@@ -83,7 +83,7 @@ class ViewController: UIViewController {
             // Closure is called when a user successfully links an Item. It should take a single LinkSuccess argument,
             // containing the publicToken String and a metadata of type SuccessMetadata.
             // Ref - https://plaid.com/docs/link/ios/#onsuccess
-            print("public-token: \(success.publicToken) metadata: \(success.metadata)")
+            print("Plaid Link succeeded. Exchange the public token on your backend; do not log it.")
         }
 
         // Optional closure is called when a user exits Link without successfully linking an Item,
@@ -92,10 +92,10 @@ class ViewController: UIViewController {
         // Ref - https://plaid.com/docs/link/ios/#onexit
         linkConfiguration.onExit = { exit in
             if let error = exit.error {
-                print("exit with \(error)\n\(exit.metadata)")
+                print("Plaid Link exited with error: \(error)")
             } else {
                 // User exited the flow without an error.
-                print("exit with \(exit.metadata)")
+                print("Plaid Link exited without an error.")
             }
         }
 
@@ -104,7 +104,7 @@ class ViewController: UIViewController {
         // what is going on as the user goes through the Plaid Link flow.
         // Ref - https://plaid.com/docs/link/ios/#onevent
         linkConfiguration.onEvent = { event in
-            print("Link Event: \(event)")
+            print("Link Event: \(event.eventName)")
         }
 
         // Set to `true` to skip the initial native loading spinner shown when Link launches.

--- a/LinkDemo-SwiftUI/LinkDemo-SwiftUI/ContentView.swift
+++ b/LinkDemo-SwiftUI/LinkDemo-SwiftUI/ContentView.swift
@@ -99,9 +99,17 @@ struct ContentView: View {
                         .plaidLink(
                             isPresented: binding(for: .modifierToken),
                             token: linkToken,
-                            onSuccess: { print("✅", $0.publicToken) },
-                            onExit: { print("🚪", $0) },
-                            onEvent: { print("📣", $0.eventName) },
+                            onSuccess: { _ in
+                                print("Plaid Link succeeded. Exchange the public token on your backend; do not log it.")
+                            },
+                            onExit: { exit in
+                                if let error = exit.error {
+                                    print("Plaid Link exited with error: \(error)")
+                                } else {
+                                    print("Plaid Link exited without an error.")
+                                }
+                            },
+                            onEvent: { print("Link Event: \($0.eventName)") },
                             onLoad: { print("Link loaded") },
                             errorView: AnyView(
                                 VStack {
@@ -152,7 +160,7 @@ struct ContentView: View {
             // Closure is called when a user successfully links an Item. It should take a single LinkSuccess argument,
             // containing the publicToken String and a metadata of type SuccessMetadata.
             // Ref - https://plaid.com/docs/link/ios/#onsuccess
-            print("public-token: \(success.publicToken) metadata: \(success.metadata)")
+            print("Plaid Link succeeded. Exchange the public token on your backend; do not log it.")
             activePresentationType = nil  // Dismiss Link
         }
 
@@ -162,10 +170,10 @@ struct ContentView: View {
         // Ref - https://plaid.com/docs/link/ios/#onexit
         linkConfiguration.onExit = { exit in
             if let error = exit.error {
-                print("exit with \(error)\n\(exit.metadata)")
+                print("Plaid Link exited with error: \(error)")
             } else {
                 // User exited the flow without an error.
-                print("exit with \(exit.metadata)")
+                print("Plaid Link exited without an error.")
             }
             activePresentationType = nil  // Dismiss Link
         }
@@ -175,7 +183,7 @@ struct ContentView: View {
         // what is going on as the user goes through the Plaid Link flow.
         // Ref - https://plaid.com/docs/link/ios/#onevent
         linkConfiguration.onEvent = { event in
-            print("Link Event: \(event)")
+            print("Link Event: \(event.eventName)")
         }
 
         // Set to `true` to skip the initial native loading spinner shown when Link launches.


### PR DESCRIPTION
## Summary
- stop printing Link public tokens in Swift, SwiftUI, and Objective-C demos
- avoid logging full Link metadata objects on success, exit, and event callbacks
- keep generic demo status output so sample flows remain understandable

## Why
Public tokens and Link metadata are sensitive enough to avoid placing in sample app logs, copied issue output, or device diagnostics.

## Testing
- git diff --check