### PR TITLE
Build example apps in PR CI

### DIFF
--- a/.github/workflows/objc-tests.yml
+++ b/.github/workflows/objc-tests.yml
@@ -1,4 +1,4 @@
-name: ObjC Tests
+name: CI
 
 on:
   pull_request:
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: plaid/plaid-link-ios-spm
-          ref: codex/objc-support-spm
+          ref: ios-link-kit-v7
           path: plaid-link-ios-spm
 
       - name: Prepare ObjC compatibility package
@@ -90,4 +90,38 @@ jobs:
             -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
             -derivedDataPath "$RUNNER_TEMP/DerivedData" \
             -clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages" \
+            CODE_SIGNING_ALLOWED=NO
+
+  build-uikit-demo:
+    name: Build UIKit Demo
+    runs-on: macos-15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Build UIKit demo app
+        run: |
+          xcodebuild build \
+            -project LinkDemo-UIKit/LinkDemo-UIKit.xcodeproj \
+            -scheme LinkDemo-UIKit \
+            -destination 'generic/platform=iOS' \
+            -derivedDataPath "$RUNNER_TEMP/UIKitDerivedData" \
+            CODE_SIGNING_ALLOWED=NO
+
+  build-swiftui-demo:
+    name: Build SwiftUI Demo
+    runs-on: macos-15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Build SwiftUI demo app
+        run: |
+          xcodebuild build \
+            -project LinkDemo-SwiftUI/LinkDemo-SwiftUI.xcodeproj \
+            -scheme LinkDemo-SwiftUI \
+            -destination 'generic/platform=iOS' \
+            -derivedDataPath "$RUNNER_TEMP/SwiftUIDerivedData" \
             CODE_SIGNING_ALLOWED=NO


### PR DESCRIPTION
## Summary
- broaden PR CI workflow name to CI
- keep the existing ObjC compatibility test job
- add PR CI jobs that build the UIKit and SwiftUI demo apps

## Testing
- GitHub Actions will run ObjC tests plus UIKit and SwiftUI demo builds on this PR