### PR TITLE
Document v7 resume after termination removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ LinkKit 7.0.0 is a major release introducing a modernized, session-based archite
 ### ⚠️ Breaking Changes & Deprecations
 
 * **Session-based API**: The legacy `Handler` API has been replaced by specialized `Session` objects (e.g., `PlaidLinkSession`, `PlaidLayerSession`).
+* **Resume After Termination Removed**: LinkKit 7 no longer restores an in-progress Link flow after the host app process is terminated. Sessions are not restorable across process termination; when the user returns, create a new session with a valid link token.
 * **CocoaPods Retirement**: CocoaPods is no longer a supported distribution method. Please migrate to **Swift Package Manager (SPM)** to continue receiving updates.
 * **Swift-Only Core**: The core `LinkKit` module is now Swift-only. For Objective-C support, you must explicitly import the new `LinkKitObjC` module.
 

--- a/v7-migration-guide.md
+++ b/v7-migration-guide.md
@@ -75,6 +75,12 @@ The new architecture moves away from a single "catch-all" Handler in favor of sp
 | :--- | :--- |
 | <pre> let result = Plaid.create(configuration) <br> switch result {<br>  case .success(let handler):<br>    // Must retain handler!<br>    self.linkHandler = handler<br>    handler.open(from: .viewController(self))<br>  case .failure(let error):<br>    print(error)<br>  }<br>}</pre> | <pre>do {<br>  let session = try Plaid.createPlaidLinkSession(<br>    configuration: configuration<br>  )<br>  // Must retain session!<br>  self.linkSession = session<br>  session.open(using: .viewController(self))<br>} catch {<br>  print(error)<br>}</pre> |
 
+##### Resume After Termination
+
+Legacy LinkKit versions supported resuming an in-progress Link flow after the host app process was terminated. LinkKit 7 removes this behavior as part of the move to session-based APIs.
+
+Do not persist `PlaidLinkSession`, `PlaidLayerSession`, or `PlaidHeadlessSession` objects with the expectation that they can be restored after process termination. If the app relaunches and the user needs to continue Link, create the appropriate session again with a fresh or still-valid link token, then present or start it from your normal entry point.
+
 Full SwiftUI Example
 
 ```swift


### PR DESCRIPTION
## Summary
- document that LinkKit 7 no longer resumes in-progress Link flows after app process termination
- add migration guidance to recreate sessions with a valid link token after relaunch

## Testing
- rg -n "resume after termination|termination|PlaidLinkSession|Breaking Changes" CHANGELOG.md v7-migration-guide.md
- manually reviewed surrounding Markdown